### PR TITLE
Configure CORS to allow requests from all regions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,8 +23,8 @@ app = FastAPI(lifespan=lifespan)
 # CORS Middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # Allows all origins
-    allow_credentials=True,
+    allow_origins=["*"],  # Allows all origins from all regions
+    allow_credentials=False,  # Must be False when allow_origins is ["*"]
     allow_methods=["*"],  # Allows all methods
     allow_headers=["*"],  # Allows all headers
 )


### PR DESCRIPTION
- Updated allow_origins from localhost:3000 to * for global access
- Set allow_credentials to False as required when allowing all origins
- Maintains full method and header flexibility